### PR TITLE
feat(retro): Add confirmation dialog to Clear All button

### DIFF
--- a/e2e/retro.spec.js
+++ b/e2e/retro.spec.js
@@ -288,8 +288,9 @@ test.describe('Retro', () => {
       await page.getByRole('button', { name: /^add$/i }).last().click()
       await expect(page.getByText('Keep this action')).toBeVisible()
 
-      // Clear all (keeping action items)
+      // Clear all (keeping action items) — confirm the dialog
       await page.getByRole('button', { name: /clear all \(keep action items\)/i }).click()
+      await page.getByRole('button', { name: /yes, clear all/i }).click()
       await expect(page.getByText('Should be cleared')).not.toBeVisible()
       await expect(page.getByText('Keep this action')).toBeVisible()
     })

--- a/src/components/retro/RetroActions.jsx
+++ b/src/components/retro/RetroActions.jsx
@@ -10,6 +10,7 @@ export default function RetroActions({
 }) {
   const [showCompleteConfirm, setShowCompleteConfirm] = useState(false);
   const [showUnfinishedWarning, setShowUnfinishedWarning] = useState(false);
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
 
   const isFinished = !!finishedParticipants[currentParticipantId];
   const unfinishedParticipants = participants.filter((p) => !finishedParticipants[p.id]);
@@ -36,15 +37,31 @@ export default function RetroActions({
   const handleClearAll = async () => {
     if (protectedCategoryId) {
       await clearAllItemsExceptCategory(teamName, protectedCategoryId);
+      setShowClearConfirm(false);
     }
   };
 
   return (
     <div className="retro-actions">
       {protectedCategoryId && (
-        <button className="duck-btn duck-btn--secondary" onClick={handleClearAll}>
-          Clear All (keep Action Items)
-        </button>
+        !showClearConfirm ? (
+          <button className="duck-btn duck-btn--secondary" onClick={() => setShowClearConfirm(true)}>
+            Clear All (keep Action Items)
+          </button>
+        ) : (
+          <span className="retro-actions__confirm">
+            <span>Clear all items except Action Items?</span>
+            <button className="duck-btn duck-btn--primary" onClick={handleClearAll}>
+              Yes, Clear All
+            </button>
+            <button
+              className="duck-btn duck-btn--secondary"
+              onClick={() => setShowClearConfirm(false)}
+            >
+              Cancel
+            </button>
+          </span>
+        )
       )}
 
       <button

--- a/src/components/retro/RetroActions.jsx
+++ b/src/components/retro/RetroActions.jsx
@@ -45,7 +45,7 @@ export default function RetroActions({
     <div className="retro-actions">
       {protectedCategoryId && (
         !showClearConfirm ? (
-          <button className="duck-btn duck-btn--secondary" onClick={() => setShowClearConfirm(true)}>
+          <button className="duck-btn duck-btn--destructive" onClick={() => setShowClearConfirm(true)}>
             Clear All (keep Action Items)
           </button>
         ) : (

--- a/src/components/retro/RetroActions.test.jsx
+++ b/src/components/retro/RetroActions.test.jsx
@@ -135,10 +135,29 @@ describe("RetroActions — I'm Finished toggle", () => {
 })
 
 describe('RetroActions — clear all', () => {
-  it('clicking Clear All calls clearAllItemsExceptCategory with team and protected category', async () => {
+  it('clicking Clear All shows a confirmation dialog', async () => {
     const user = userEvent.setup()
     renderActions()
     await user.click(screen.getByRole('button', { name: /clear all/i }))
+    expect(screen.getByText(/clear all items except action items/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /yes, clear all/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('confirming calls clearAllItemsExceptCategory with team and protected category', async () => {
+    const user = userEvent.setup()
+    renderActions()
+    await user.click(screen.getByRole('button', { name: /clear all/i }))
+    await user.click(screen.getByRole('button', { name: /yes, clear all/i }))
     expect(clearAllItemsExceptCategory).toHaveBeenCalledWith(TEAM, PROTECTED_CATEGORY_ID)
+  })
+
+  it('canceling hides confirmation and does not call clearAllItemsExceptCategory', async () => {
+    const user = userEvent.setup()
+    renderActions()
+    await user.click(screen.getByRole('button', { name: /clear all/i }))
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(clearAllItemsExceptCategory).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /clear all/i })).toBeInTheDocument()
   })
 })

--- a/src/components/run-stand-up/run-standup.css
+++ b/src/components/run-stand-up/run-standup.css
@@ -231,6 +231,18 @@
   border-color: #9A918A;
 }
 
+.duck-btn--destructive {
+  background: transparent;
+  color: #A04F38;
+  border: 1px solid #C8846E;
+}
+
+.duck-btn--destructive:hover {
+  background: #FEF2EC;
+  color: #7A3321;
+  border-color: #A04F38;
+}
+
 /* ---------- Message card ---------- */
 .message-card {
   background: #FDFBF7;


### PR DESCRIPTION
Add a confirmation step to the \"Clear All (keep Action Items)\" button on the retro board.

Previously, clicking the button immediately wiped all retro items — easy to do by accident and unrecoverable. The button now shows an inline \"Clear all items except Action Items? / Yes, Clear All / Cancel\" prompt before executing, matching the same pattern already used for the Complete Retro confirmation.

Unit tests expanded to cover the confirmation dialog, cancel behaviour, and the actual clear path. The e2e spec updated to click through the confirmation step.