### PR TITLE
feat(retro): Include agreed-with items in participant filter

### DIFF
--- a/src/components/retro/RetroBoard.jsx
+++ b/src/components/retro/RetroBoard.jsx
@@ -86,7 +86,10 @@ export default function RetroBoard({ teamName, participants }) {
     ? Object.values(retroState.items)
     : [];
   const items = filterParticipantId
-    ? allItems.filter(item => item.authorId === filterParticipantId)
+    ? allItems.filter(item =>
+        item.authorId === filterParticipantId ||
+        item.agreedBy?.[filterParticipantId]
+      )
     : allItems;
 
   // Find the protected (Action Items) category

--- a/src/components/retro/RetroBoard.test.jsx
+++ b/src/components/retro/RetroBoard.test.jsx
@@ -168,7 +168,7 @@ describe('RetroBoard — participant filter', () => {
     expect(screen.queryByText('Bob cat1')).not.toBeInTheDocument()
   })
 
-  it('only shows items authored by the participant, not items they agreed with', async () => {
+  it('shows items the participant agreed with, in addition to items they authored', async () => {
     const user = userEvent.setup()
     mockSubscribe({
       ...retroWithItems,
@@ -180,10 +180,10 @@ describe('RetroBoard — participant filter', () => {
       },
     })
     renderBoard()
-    // Filter by Bob — should not see Alice's item even though Bob agreed with it
+    // Filter by Bob — should see Alice's item because Bob agreed with it
     await user.selectOptions(screen.getByRole('combobox', { name: /filter/i }), 'p2')
-    expect(screen.queryByText('Alice item')).not.toBeInTheDocument()
-    // Filter by Alice — should see her item
+    expect(screen.getByText('Alice item')).toBeInTheDocument()
+    // Filter by Alice — should see her item as author
     await user.selectOptions(screen.getByRole('combobox', { name: /filter/i }), 'p1')
     expect(screen.getByText('Alice item')).toBeInTheDocument()
   })


### PR DESCRIPTION
The participant filter previously only showed items the user authored. It now also includes items they agreed with (upvoted), giving a complete view of their engagement with the retro.

The `agreedBy` field on each retro item is a map of `{ [participantId]: true }`, so the filter extends the existing `authorId` check with an optional-chain lookup into that map — no data model changes needed.